### PR TITLE
Fix compilation issue - wrong package

### DIFF
--- a/site/src/main/java/com/community/configuration/SiteSecurityConfig.java
+++ b/site/src/main/java/com/community/configuration/SiteSecurityConfig.java
@@ -3,7 +3,7 @@ package com.community.configuration;
 import org.broadleafcommerce.common.security.BroadleafAuthenticationFailureHandler;
 import org.broadleafcommerce.common.security.handler.SecurityFilter;
 import org.broadleafcommerce.core.web.order.security.BroadleafAuthenticationSuccessHandler;
-import org.broadleafcommerce.profile.web.core.security.SessionFixationProtectionFilter;
+import org.broadleafcommerce.profile.web.site.security.SessionFixationProtectionFilter;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;


### PR DESCRIPTION
org.broadleafcommerce.profile.web.core.security.SessionFixationProtectionFilter class has been moved to a new renamed package. 

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project boot-community-demo-site: Compilation failure: Compilation failure: [ERROR] /opt/broadleaf/CommunityStarter/site/src/main/java/com/community/configuration/SiteSecurityConfig.java:[6,55] cannot find symbol [ERROR] symbol: class SessionFixationProtectionFilter [ERROR] location: package org.broadleafcommerce.profile.web.core.security [ERROR] /opt/broadleaf/CommunityStarter/site/src/main/java/com/community/configuration/SiteSecurityConfig.java:[223,139] cannot find symbol [ERROR] symbol: class SessionFixationProtectionFilter [ERROR] location: class com.community.configuration.SiteSecurityConfig [ERROR] -> [Help 1]