### PR TITLE
Fix french translation

### DIFF
--- a/site/src/main/resources/messages_fr.properties
+++ b/site/src/main/resources/messages_fr.properties
@@ -1,38 +1,38 @@
 #addresses
-addressName.required=S'il vous pla&icirc;t entrer un nom pour votre adresse
-addressLine1.required=S'il vous pla&icirc;t entrez l'adresse r&eacute;elle.
-city.required=S'il vous pla&icirc;t entrer dans la ville.
-state.required=S'il vous pla&icirc;t entrer dans l'&eacute;tat.
-postalCode.required=Please enter the postal code.
+addressName.required=S'il vous pla&icirc;t saisissez un nom pour votre adresse
+addressLine1.required=S'il vous pla&icirc;t saisissez l'adresse correspondante.
+city.required=S'il vous pla&icirc;t saisissez le nom de la ville.
+state.required=S'il vous pla&icirc;t saisissez le nom de votre &eacute;tat.
+postalCode.required=S'il vous pla&icirc;t saisissez le code postal.
 
 #registration
-fullName.required=S'il vous pla&icirc;t entrez votre nom.
-firstName.required=S'il vous pla&icirc;t entrez le code postal.
-firstName.invalid=S'il vous pla&icirc;t entrer un pr&eacute;nom valide
+fullName.required=S'il vous pla&icirc;t entrez votre nom complet.
+firstName.required=S'il vous pla&icirc;t entrez votre pr&eacute;nom.
+firstName.invalid=S'il vous pla&icirc;t entrez un pr&eacute;nom valide
 lastName.required=S'il vous pla&icirc;t entrez votre nom de famille.
-lastName.invalid=S'il vous pla&icirc;t entrer un nom valide
+lastName.invalid=S'il vous pla&icirc;t entrez un nom de famille valide
 username.required=S'il vous pla&icirc;t fournir une valeur pour le champ "Nom d'utilisateur" champ de ce formulaire.
 username.used=Un utilisateur existe d&eacute;j&agrave; avec ce nom d'utilisateur.
 password.required=Mot de passe doit &ecirc;tre alphanum&eacute;rique
-password.invalid=S'il vous pla&icirc;t entrer un mot de passe valide
-passwordConfirm.required=S'il vous pla&icirc;t confirmer votre mot de passe
+password.invalid=S'il vous pla&icirc;t entrez un mot de passe valide
+passwordConfirm.required=S'il vous pla&icirc;t confirmez votre mot de passe
 passwordConfirm.invalid=Les mots de passe ne correspondent pas
 emailAddress.required=S'il vous pla&icirc;t, entrez votre adresse e-mail.
 emailAddress.used=Cette adresse email est d&eacute;j&agrave; utilis&eacute;.
-emailAddress.invalid=Adresse email est invalide
+emailAddress.invalid=L'adresse email est invalide
 
 #fulfillment
 fulfillmentOptionId.required=S'il vous pla&icirc;t s&eacute;lectionner un mode de livraison.
-payment.exception=Il y avait un probl&egrave;me lors du traitement de votre paiement. S'il vous pla&icirc;t examiner vos renseignements.
+payment.exception=Un probl&egrave;me est survenu lors du traitement de votre paiement. S'il vous pla&icirc;t v&eacute;rifiez vos informations.
 
 #phones
-phone.invalid=A phone number is required, and it must be valid. 
-phone.required=A phone number is required.
-phoneName.required=A Phone Name is required.
-phoneName.duplicate=A Phone with that Name already exists.      
-phoneNumber.duplicate=A Phone with that Number already exists. 
-phone.ten_digits_required=10 digits are required for your phone number. 
-phone.invalid_id=An ID was passed in that does not belong to the logged in user. 
+phone.invalid=Le num&eacute;ro de t&eacute;l&eacute;phone est requis et il doit être valide.
+phone.required=Le num&eacute;ro de t&eacute;l&eacute;phone est requis.
+phoneName.required=Le nom pour ce n&deg; de t&eacute;l&eacute;phone est requis.
+phoneName.duplicate=Un n&deg; de t&eacute;l&eacute;phone existes d&eacute;j&agrave; pour ce nom.
+phoneNumber.duplicate=Il existe d&eacute;j&agrave; un t&eacute;l&eacute;phone avec ce num&eacute;ro.
+phone.ten_digits_required=10 chiffres sont requis pour le &deg; de t&eacute;l&eacute;phone.
+phone.invalid_id=L'id ID qui a &eacute;t&eacute; fourni n'appartient pas &agrave; l'utilisateur loggu&eacute;.
 
 #account
 account.giftCard.title = Saisir le num&eacute;ro de la Carte Cadeau:
@@ -46,30 +46,30 @@ account.giftCard.giftcard.number=Num&eacute;ro de la Carte Cadeau
 account.giftCard.date=Date
 
 #credit card
-creditCardName.required= Nom de la carte de cr&eacute;dit est requise.
-creditCardNumber.required= Num&eacute;ro de carte de cr&eacute;dit est requise.
-creditCardCvvCode.required= Code CVV est n&eacute;cessaire.
-creditCardExpMonth.required= Mois d'expiration de carte de cr&eacute;dit est requise.
-creditCardExpYear.required= Ann&eacute;e d'expiration de carte de cr&eacute;dit est requise.
+creditCardName.required= Nom de la carte de cr&eacute;dit requis.
+creditCardNumber.required= Num&eacute;ro de la carte de cr&eacute;dit requis.
+creditCardCvvCode.required= Code CVV requis.
+creditCardExpMonth.required= Mois d'expiration de la carte de cr&eacute;dit requis.
+creditCardExpYear.required= Ann&eacute;e d'expiration de la carte de cr&eacute;dit requise.
 
 #gift card
-giftCardNumber.required=Gift Card Number is required.
-giftCardEmailAddress.required=Email is required.
-giftCardEmailAddress.invalid=Email address is invalid
+giftCardNumber.required=Num&eacute;ro Carte Cadeau requis.
+giftCardEmailAddress.required=Email requis.
+giftCardEmailAddress.invalid=Adresse email invalide.
 
 #payment
-payment.exception.review= Please review your information.
-payment.transaction.error=There was a problem processing your payment. Please review your information.
-payment.exception.giftCard.expired=The gift card entered has expired.
-payment.option.exception=There was a problem processing your payment options.
-payment.exception.warning=There was a problem processing your payment.
+payment.exception.review= S'il vous pla&icirc;t v&eacute;rifiez vos informations.
+payment.transaction.error=Un probl&egrave;me est survenu lors du traitement de votre paiement. S'il vous pla&icirc;t v&eacute;rifiez vos informations.
+payment.exception.giftCard.expired=La carte cadeau saisie est expir&eacute;e.
+payment.option.exception=Un probl&egrave;me est survenu lors du traitement de vos options de paiement.
+payment.exception.warning=Un probl&egrave;me est survenu lors du traitement de votre paiement.
 
 #password change
-currentPassword.required=S'il vous pla&icirc;t entrer votre mot de passe actuel.
-currentPassword.invalid=Mot de passe actuel est incorrecte.
-newPassword.required=S'il vous pla&icirc;t entrer votre nouveau mot de passe.
-newPassword.invalid=S'il vous pla&icirc;t entrer un mot de passe avec au moins 5 caract&egrave;res.
-newPasswordConfirm.required=S'il vous pla&icirc;t confirmer votre nouveau mot de passe.
+currentPassword.required=S'il vous pla&icirc;t entrez votre mot de passe actuel.
+currentPassword.invalid=le mot de passe est incorrect.
+newPassword.required=S'il vous pla&icirc;t entrez votre nouveau mot de passe.
+newPassword.invalid=S'il vous pla&icirc;t entrez un mot de passe avec au moins 5 caract&egrave;res.
+newPasswordConfirm.required=S'il vous pla&icirc;t confirmez votre nouveau mot de passe.
 newPasswordConfirm.invalid=Les mots de passe ne correspondent pas.
 
 #multiship
@@ -77,8 +77,8 @@ address.required=S'il vous pla&icirc;t s&eacute;lectionnez une adresse
 option.required=S'il vous pla&icirc;t s&eacute;lectionnez une option
 
 #Header
-home.login = Login
-home.register = Enregistrer
+home.login = Connexion
+home.register = Cr&eacute;er un compte
 home.logout = D&eacute;connexion
 home.welcome = Accueil
 home.item = article
@@ -87,11 +87,11 @@ home.items = articles
 #Login
 login.loginToAccount = Connectez-vous &agrave; votre compte
 login.alreadyMember = D&eacute;j&agrave; membre? Se connecter en utilisant le formulaire ci-dessous
-login.noMatchTryAgain = L'adresse e-mail et / ou mot de passe entr&eacute; ne correspond pas &agrave; nos dossiers. S'il vous pla&icirc;t essayez de nouveau
+login.noMatchTryAgain = Impossible de trouver l'adresse e-mail et / ou mot de passe entr&eacute; correspondant. S'il vous pla&icirc;t essayez de nouveau
 login.email = Email
 login.password = Mot de passe
-login.login = Login
-login.register = Enregistrer
+login.login = Connexion
+login.register = Cr&eacute;er un compte
 login.forgotPassword = Mot de passe oubli&eacute;
 
 #Register
@@ -102,16 +102,16 @@ register.firstName = Pr&eacute;nom
 register.lastName = Nom de famille
 register.password = Mot de passe
 register.confirmPassword = Confirmer mot de passe
-register.login = Login
+register.login = Connexion
 register.forgotPassword = Mot de passe oubli&eacute;
-register.register = Enregistrer
+register.register = Cr&eacute;er un compte
 
 #Product
 product.buyNow = Acheter!
 product.inCart = Dans le panier!
 
 #Product Options
-product.allOptionsRequired = Toutes les options sont n&eacute;cessaires
+product.allOptionsRequired = Toutes les options sont obligatoires.
 
 #Category
 category.filterResults = Filtrez vos r&eacute;sultats
@@ -124,25 +124,25 @@ search.filterSearch = Filtrez votre recherche
 search.featuredProducts = Produits &agrave; la une
 search.results = R&eacute;sultats de la recherche
 search.of = de
-search.resultsFor = R&eacute;sultats de la recherche de
+search.resultsFor = R&eacute;sultats de la recherche pour
 
 #Cart
-cart.currentSubtotal = Votre Sous-total actuel
-cart.orderDiscount = Remise afin
-cart.subtotalDisclaimer = Sous-total n'inclut pas encore les taxes applicables ou exp&eacute;dition et de manutention
+cart.currentSubtotal = Votre sous-total actuel
+cart.orderDiscount = Remise commande
+cart.subtotalDisclaimer = Le sous-total n'inclut pas encore les taxes, les frais de livraison ou de manutention.
 cart.update = Mettre &agrave; jour
 cart.remove = Supprimer
-cart.checkout = Caisse
-cart.continueShopping = Continuer les achats
+cart.checkout = Passer la commande
+cart.continueShopping = Continuer mes achats
 cart.promoCode = Code promotionnel
-cart.applyDiscount = Appliquer Discount
+cart.applyDiscount = Appliquer la promotion
 cart.item = Article
 cart.quantity = Quantit&eacute;
 cart.price = Prix
 cart.discount = R&eacute;duction
-cart.totalSavings = R&eacute;duction 
+cart.totalSavings = Total des r&eacute;ductions 
 cart.total = Total
-cart.each = (chaque)
+cart.each = (chacun)
 cart.empty = Votre panier est vide
 cart.orderSummary = R&eacute;sum&eacute; de la commande
 cart.edit = &Eacute;diter
@@ -151,43 +151,43 @@ cart.step2 = &Eacute;tape 2
 cart.step3 = &Eacute;tape 3
 cart.step4 = &Eacute;tape 4
 cart.step5 = &Eacute;tape 5
-cart.orderInformation = Informations de commande
-cart.billingInformation = Informations sur la facturation
-cart.shippingInformation = Informations sur la livraison
+cart.orderInformation = Informations sur la commande
+cart.billingInformation = Informations de facturation
+cart.shippingInformation = Informations de livraison
 cart.fillOutBasicOrder = S'il vous pla&icirc;t remplissez les informations de base afin de finaliser l'achat
 cart.orderTotal = Total de la commande
-cart.orderSubTotal = Subtotal
+cart.orderSubTotal = Sous-total
 cart.promotions = Promotions
-cart.taxes = Imp&ocirc;ts
-cart.shipping = Transport maritime
-cart.billing.info = Information sur la facturation
-cart.fillOutShippingAddress = S'il vous pla&icirc;t remplir une adresse de livraison et de choisir une m&eacute;thode d'exp&eacute;dition pour r&eacute;aliser cet achat
+cart.taxes = Taxes
+cart.shipping = Livraison
+cart.billing.info = Information de facturation
+cart.fillOutShippingAddress = S'il vous pla&icirc;t saisissez une adresse de livraison et choisissez un mode de livraison pour r&eacute;aliser cet achat
 cart.addNewAddress = Ajouter une adresse...
-cart.paymentProcessingError = There was an error processing your payment. Please try again.
-cart.payment.expiration.invalid = The expiration date is invalid. Please use (MM/YY)
-cart.payment.card.invalid = The card number you entered is invalid.
-cart.payment.invalid = There was a problem processing your request. Invalid Arguments.
+cart.paymentProcessingError = Une erreur est survenue lors du traitement de votre paiement. S'il vous pla&icirc;t essayez de nouveau.
+cart.payment.expiration.invalid = La date d'expiration est invalide. S'il vous pla&icirc;t utilisez (MM/AA)
+cart.payment.card.invalid = Le num&eacute;ro de carte saisi est invalide.
+cart.payment.invalid = Un probl&egrave;me est survenu lors du traitement de votre demande. Param&egrave;tres invalides.
 
 #Cart - Order Info
-cart.checkoutByFillingInEmail = Caisse en tant qu'invit&eacute; en remplissant un e-mail ou
-cart.logIntoYourAccount = Connectez-vous &agrave; votre compte
+cart.checkoutByFillingInEmail = Passez votre commande en tant qu'invit&eacute;; en fournissant un e-mail ou
+cart.logIntoYourAccount = connectez-vous &agrave; votre compte
 cart.youCanAlso = Vous pouvez &eacute;galement
-cart.registerNewAccount = enregistrer un nouveau compte
+cart.registerNewAccount = cr&eacute;er un nouveau compte
 cart.emailAddress = Adresse e-mail
-cart.checkoutAsGuest = Commander tant qu'invit&eacute;
+cart.checkoutAsGuest = Commander en tant qu'invit&eacute;
 
 #Cart - Shipping Info / Billing Info
-cart.useShppingInfo = Utilisez Informations sur la livraison
-cart.useBillingInfo = Utilisez Informations sur la facturation
+cart.useShppingInfo = Utiliser les informations de livraison
+cart.useBillingInfo = Utiliser les informations de facturation
 cart.firstName = Pr&eacute;nom
 cart.lastName = Nom de famille
 cart.phone = T&eacute;l&eacute;phone
 cart.address2 = Addresse 2
-cart.cityState = Ville / &eacute;tat
+cart.cityState = Ville / &Eacute;tat
 cart.postalCode  = Code postal
-cart.shppingMethod = M&eacute;thode d'exp&eacute;dition
-cart.selectShipping = S&eacute;lectionnez exp&eacute;dition
-cart.shipToMultipleAddresses = Envoyer &agrave; des adresses multiples
+cart.shppingMethod = M&eacute;thode de livraison
+cart.selectShipping = Choisir le mode de livraison
+cart.shipToMultipleAddresses = Exp&eacute;dier &agrave; &agrave; plusieurs adresses
 cart.shippingAddress = Adresse de livraison
 cart.shppingTotal = Exp&eacute;dition Total
 cart.billingAddress = Adresse de facturation
@@ -195,7 +195,7 @@ cart.paymentMethod = Mode de paiement
 cart.creditCard = Carte de cr&eacute;dit
 cart.cardNumber = Num&eacute;ro de la carte
 cart.cvv = CVV
-cart.cardType = Card Type
+cart.cardType = Type de carte
 cart.nameOnCard = Nom
 cart.experationDate = Date d'expiration
 cart.payPal = PayPal
@@ -208,7 +208,7 @@ cart.giftCard.email = Email
 cart.giftCardNumber = Numexp&eacute;ro carte cadeau
 cart.giftCard.apply = Appliquer
 cart.completOrder = Terminer la commande
-cart.payment.options = Choix du moyen de paiement
+cart.payment.options = Options de paiement
 cart.payment.accountCredit = Cartes Cadeau et Avoirs Client
 cart.payment.promo = Code promo
 cart.customer.credit = Avoir client
@@ -220,25 +220,25 @@ cart.addAddress = Ajouter une nouvelle adresse
 cart.cancel = Annuler
 
 #Confirmation
-confirmation.success = Succ&egrave;s!
+confirmation.success = F&eacute;licitations!
 confirmation.orderNum = Confirmation de commande #
-confirmation.confirmEmail.toBeSent = Un email de confirmation sera envoy&eacute; &agrave;
+confirmation.confirmEmail.toBeSent = Un email de confirmation vous sera envoy&eacute; &agrave;
 confirmation.orderSummary = R&eacute;sum&eacute; de la commande
 confirmation.orderTotal = Total de la commande
 confirmation.orderSubTotal = Sous-total
 confirmation.promotions = Promotions
-confirmation.taxes = Imp�ts
-confirmation.shipping = Transport maritime
-confirmation.shipping.info = Informations sur la livraison
-confirmation.shipping.method = M&eacute;thode d'exp&eacute;dition
-confirmation.billing.info = Information sur la facturation
-confirmation.payment.info = Conditions de vente
+confirmation.taxes = Taxes
+confirmation.shipping = Livraison
+confirmation.shipping.info = Informations de livraison
+confirmation.shipping.method = Mode de livraison
+confirmation.billing.info = Informations de facturation
+confirmation.payment.info = Informations sur le paiement
 confirmation.payment.method = Mode de paiement
 confirmation.exp = exp.
 
 #Facet Filter
-facet.chooseMultiple = Choisissez multiple...
-facet.edit = &Eacute;diter
+facet.chooseMultiple = S&eacute;lectionner plusieurs...
+facet.edit = Modifier
 facet.orMore = ou plus
 
 #Product Sort Options
@@ -250,11 +250,11 @@ productSortOptions.name = Nom
 productPagingOptions.page= Page
 
 #Footer
-footer.delivering = Offrir Texas Heat Sized
-footer.since1978 = Depuis Nineteen Seventy Huit
-footer.copyrightHC = Copyright 2012 The Heat Clinic
+footer.delivering = Vous offrir la chaleur du Texas
+footer.since1978 = Depuis 1978
+footer.copyrightHC = Copyright 2017 The Heat Clinic
 footer.allRights = Tous droits r&eacute;serv&eacute;s
 footer.privacyPolicy = Politique de confidentialit&eacute;
 footer.customerService = Service &agrave; la client&egrave;le
 footer.branding.poweredByBLC = Propuls&eacute; par Broadleaf Commerce
-footer.branding.copyrightBLC = Copyright 2012 Broadleaf Commerce
+footer.branding.copyrightBLC = Copyright 2017 Broadleaf Commerce

--- a/site/src/main/resources/messages_fr.properties
+++ b/site/src/main/resources/messages_fr.properties
@@ -26,7 +26,7 @@ fulfillmentOptionId.required=S'il vous pla&icirc;t s&eacute;lectionner un mode d
 payment.exception=Un probl&egrave;me est survenu lors du traitement de votre paiement. S'il vous pla&icirc;t v&eacute;rifiez vos informations.
 
 #phones
-phone.invalid=Le num&eacute;ro de t&eacute;l&eacute;phone est requis et il doit être valide.
+phone.invalid=Le num&eacute;ro de t&eacute;l&eacute;phone est requis et il doit &ecirc;tre valide.
 phone.required=Le num&eacute;ro de t&eacute;l&eacute;phone est requis.
 phoneName.required=Le nom pour ce n&deg; de t&eacute;l&eacute;phone est requis.
 phoneName.duplicate=Un n&deg; de t&eacute;l&eacute;phone existes d&eacute;j&agrave; pour ce nom.
@@ -237,7 +237,7 @@ confirmation.payment.method = Mode de paiement
 confirmation.exp = exp.
 
 #Facet Filter
-facet.chooseMultiple = S&eacute;lectionner plusieurs...
+facet.chooseMultiple = Choix multiple...
 facet.edit = Modifier
 facet.orMore = ou plus
 

--- a/site/src/main/resources/messages_fr.properties
+++ b/site/src/main/resources/messages_fr.properties
@@ -6,6 +6,7 @@ state.required=S'il vous pla&icirc;t entrer dans l'&eacute;tat.
 postalCode.required=Please enter the postal code.
 
 #registration
+fullName.required=S'il vous pla&icirc;t entrez votre nom.
 firstName.required=S'il vous pla&icirc;t entrez le code postal.
 firstName.invalid=S'il vous pla&icirc;t entrer un pr&eacute;nom valide
 lastName.required=S'il vous pla&icirc;t entrez votre nom de famille.
@@ -25,20 +26,43 @@ fulfillmentOptionId.required=S'il vous pla&icirc;t s&eacute;lectionner un mode d
 payment.exception=Il y avait un probl&egrave;me lors du traitement de votre paiement. S'il vous pla&icirc;t examiner vos renseignements.
 
 #phones
-phone.invalid=Un num&eacute;ro de t&eacute;l&eacute;phone est n&eacute;cessaire, et il doit &ecirc;tre valide.
-phone.required=Un num&eacute;ro de t&eacute;l&eacute;phone est n&eacute;cessaire.
-phoneName.required=Un Nom T&eacute;l&eacute;phone est n&eacute;cessaire.
-phoneName.duplicate=Un t&eacute;l&eacute;phone avec ce nom existe d&eacute;j&agrave;.
-phoneNumber.duplicate=Un t&eacute;l&eacute;phone &agrave; ce num&eacute;ro existe d&eacute;j&agrave;.
-phone.ten_digits_required=10 chiffres sont n&eacute;cessaires pour votre num&eacute;ro de t&eacute;l&eacute;phone.
-phone.invalid_id=Une pi&egrave;ce d'identit&eacute; a &eacute;t&eacute; adopt&eacute;e en ce qui n'appartient pas &agrave; l'utilisateur connect&eacute;.
+phone.invalid=A phone number is required, and it must be valid. 
+phone.required=A phone number is required.
+phoneName.required=A Phone Name is required.
+phoneName.duplicate=A Phone with that Name already exists.      
+phoneNumber.duplicate=A Phone with that Number already exists. 
+phone.ten_digits_required=10 digits are required for your phone number. 
+phone.invalid_id=An ID was passed in that does not belong to the logged in user. 
 
-#payment
+#account
+account.giftCard.title = Saisir le num&eacute;ro de la Carte Cadeau:
+account.giftCard.number = Num&eacute;ro
+account.giftCard.balance = Solde restant
+account.giftCard.amountApplied = Montant appliqu&eacute;
+account.giftCard.status=Statut
+account.giftCard.invalid.number=La Carte Cadeau saisie n'a pas &eacute;t&eacute; trouv&eacute;e? Veuille&eacute; r&eacute;essayer.
+account.giftCard.already.redeemed=Carte Cadeau d&eacute;j&agrave; consomm&eacute;e
+account.giftCard.giftcard.number=Num&eacute;ro de la Carte Cadeau
+account.giftCard.date=Date
+
+#credit card
 creditCardName.required= Nom de la carte de cr&eacute;dit est requise.
 creditCardNumber.required= Num&eacute;ro de carte de cr&eacute;dit est requise.
 creditCardCvvCode.required= Code CVV est n&eacute;cessaire.
 creditCardExpMonth.required= Mois d'expiration de carte de cr&eacute;dit est requise.
 creditCardExpYear.required= Ann&eacute;e d'expiration de carte de cr&eacute;dit est requise.
+
+#gift card
+giftCardNumber.required=Gift Card Number is required.
+giftCardEmailAddress.required=Email is required.
+giftCardEmailAddress.invalid=Email address is invalid
+
+#payment
+payment.exception.review= Please review your information.
+payment.transaction.error=There was a problem processing your payment. Please review your information.
+payment.exception.giftCard.expired=The gift card entered has expired.
+payment.option.exception=There was a problem processing your payment options.
+payment.exception.warning=There was a problem processing your payment.
 
 #password change
 currentPassword.required=S'il vous pla&icirc;t entrer votre mot de passe actuel.
@@ -125,17 +149,24 @@ cart.edit = &Eacute;diter
 cart.step1 = &Eacute;tape 1
 cart.step2 = &Eacute;tape 2
 cart.step3 = &Eacute;tape 3
+cart.step4 = &Eacute;tape 4
+cart.step5 = &Eacute;tape 5
 cart.orderInformation = Informations de commande
+cart.billingInformation = Informations sur la facturation
 cart.shippingInformation = Informations sur la livraison
 cart.fillOutBasicOrder = S'il vous pla&icirc;t remplissez les informations de base afin de finaliser l'achat
 cart.orderTotal = Total de la commande
 cart.orderSubTotal = Subtotal
 cart.promotions = Promotions
-cart.taxes = Imp™ts
+cart.taxes = Imp&ocirc;ts
 cart.shipping = Transport maritime
 cart.billing.info = Information sur la facturation
 cart.fillOutShippingAddress = S'il vous pla&icirc;t remplir une adresse de livraison et de choisir une m&eacute;thode d'exp&eacute;dition pour r&eacute;aliser cet achat
 cart.addNewAddress = Ajouter une adresse...
+cart.paymentProcessingError = There was an error processing your payment. Please try again.
+cart.payment.expiration.invalid = The expiration date is invalid. Please use (MM/YY)
+cart.payment.card.invalid = The card number you entered is invalid.
+cart.payment.invalid = There was a problem processing your request. Invalid Arguments.
 
 #Cart - Order Info
 cart.checkoutByFillingInEmail = Caisse en tant qu'invit&eacute; en remplissant un e-mail ou
@@ -147,6 +178,7 @@ cart.checkoutAsGuest = Commander tant qu'invit&eacute;
 
 #Cart - Shipping Info / Billing Info
 cart.useShppingInfo = Utilisez Informations sur la livraison
+cart.useBillingInfo = Utilisez Informations sur la facturation
 cart.firstName = Pr&eacute;nom
 cart.lastName = Nom de famille
 cart.phone = T&eacute;l&eacute;phone
@@ -158,14 +190,28 @@ cart.selectShipping = S&eacute;lectionnez exp&eacute;dition
 cart.shipToMultipleAddresses = Envoyer &agrave; des adresses multiples
 cart.shippingAddress = Adresse de livraison
 cart.shppingTotal = Exp&eacute;dition Total
-cart.paymentInfo = Conditions de vente
+cart.billingAddress = Adresse de facturation
+cart.paymentMethod = Mode de paiement
 cart.creditCard = Carte de cr&eacute;dit
 cart.cardNumber = Num&eacute;ro de la carte
 cart.cvv = CVV
+cart.cardType = Card Type
 cart.nameOnCard = Nom
 cart.experationDate = Date d'expiration
 cart.payPal = PayPal
+cart.collectOnDelivery=Paiement &agrave; la livraison
+cart.giftCard = Carte cadeau
+cart.giftCard.applied = Cartes cadeau utilis&eacute;es
+cart.giftCard.number = Numexp&eacute;ro
+cart.giftCard.balance = Solde
+cart.giftCard.email = Email
+cart.giftCardNumber = Numexp&eacute;ro carte cadeau
+cart.giftCard.apply = Appliquer
 cart.completOrder = Terminer la commande
+cart.payment.options = Choix du moyen de paiement
+cart.payment.accountCredit = Cartes Cadeau et Avoirs Client
+cart.payment.promo = Code promo
+cart.customer.credit = Avoir client
 
 #Cart - Multiship
 cart.address = Addresse
@@ -179,14 +225,15 @@ confirmation.orderNum = Confirmation de commande #
 confirmation.confirmEmail.toBeSent = Un email de confirmation sera envoy&eacute; &agrave;
 confirmation.orderSummary = R&eacute;sum&eacute; de la commande
 confirmation.orderTotal = Total de la commande
-confirmation.orderSubTotal = Subtotal
+confirmation.orderSubTotal = Sous-total
 confirmation.promotions = Promotions
-confirmation.taxes = Imp™ts
+confirmation.taxes = Impï¿½ts
 confirmation.shipping = Transport maritime
 confirmation.shipping.info = Informations sur la livraison
 confirmation.shipping.method = M&eacute;thode d'exp&eacute;dition
 confirmation.billing.info = Information sur la facturation
 confirmation.payment.info = Conditions de vente
+confirmation.payment.method = Mode de paiement
 confirmation.exp = exp.
 
 #Facet Filter

--- a/site/src/main/resources/messages_fr.properties
+++ b/site/src/main/resources/messages_fr.properties
@@ -87,7 +87,7 @@ home.items = articles
 #Login
 login.loginToAccount = Connectez-vous &agrave; votre compte
 login.alreadyMember = D&eacute;j&agrave; membre? Se connecter en utilisant le formulaire ci-dessous
-login.noMatchTryAgain = Impossible de trouver l'adresse e-mail et / ou mot de passe entr&eacute; correspondant. S'il vous pla&icirc;t essayez de nouveau
+login.noMatchTryAgain = Impossible de trouver l'adresse e-mail et/ou mot de passe correspondant. S'il vous pla&icirc;t essayez de nouveau
 login.email = Email
 login.password = Mot de passe
 login.login = Connexion
@@ -96,10 +96,10 @@ login.forgotPassword = Mot de passe oubli&eacute;
 
 #Register
 register.registerForAccount = Ouvrir un compte
-register.signUpNow = Vous n'avez pas encore de compte? Ouvrez-en un maintenant pour acc&eacute;der &agrave; tous nos outils de membres
+register.signUpNow = Vous n'avez pas encore de compte? Ouvrez-en un maintenant pour acc&eacute;der &agrave; votre espace membre.
 register.email = Email
 register.firstName = Pr&eacute;nom
-register.lastName = Nom de famille
+register.lastName = Nom
 register.password = Mot de passe
 register.confirmPassword = Confirmer mot de passe
 register.login = Connexion
@@ -129,7 +129,7 @@ search.resultsFor = R&eacute;sultats de la recherche pour
 #Cart
 cart.currentSubtotal = Votre sous-total actuel
 cart.orderDiscount = Remise commande
-cart.subtotalDisclaimer = Le sous-total n'inclut pas encore les taxes, les frais de livraison ou de manutention.
+cart.subtotalDisclaimer = Le sous-total n'inclut pas encore les taxes, les frais de livraison ou de manutention
 cart.update = Mettre &agrave; jour
 cart.remove = Supprimer
 cart.checkout = Passer la commande
@@ -180,7 +180,7 @@ cart.checkoutAsGuest = Commander en tant qu'invit&eacute;
 cart.useShppingInfo = Utiliser les informations de livraison
 cart.useBillingInfo = Utiliser les informations de facturation
 cart.firstName = Pr&eacute;nom
-cart.lastName = Nom de famille
+cart.lastName = Nom
 cart.phone = T&eacute;l&eacute;phone
 cart.address2 = Addresse 2
 cart.cityState = Ville / &Eacute;tat

--- a/site/src/main/resources/messages_fr.properties
+++ b/site/src/main/resources/messages_fr.properties
@@ -111,7 +111,7 @@ product.buyNow = Acheter!
 product.inCart = Dans le panier!
 
 #Product Options
-product.allOptionsRequired = Toutes les options sont obligatoires.
+product.allOptionsRequired = Toutes les options sont obligatoires
 
 #Category
 category.filterResults = Filtrez vos r&eacute;sultats


### PR DESCRIPTION
- Added missing french translations
- messages_fr.properties has now the same n# of entries and in the same order than the default messages.properties file (en)
- Fixed the clunky french translation

Translation is still perfectible but at least it is more correct now. (French are very susceptible about french language)

-I kept using html code for accented characters
-I kept upper/lower case in the translated word and final dot at the end if present in the english message.
-I use (if possible) the translation with the smallest length to not break the css.

Please note that accented characters may not be correctly displayed but is is linked to  #10
