### PR TITLE
Fix to incorrect email template resolution

### DIFF
--- a/core/src/main/java/com/community/core/config/CoreEmailConfig.java
+++ b/core/src/main/java/com/community/core/config/CoreEmailConfig.java
@@ -52,7 +52,7 @@ public class CoreEmailConfig {
     
     @Bean
     public EmailInfo blEmailInfo() {
-        EmailInfo info = new EmailInfo();
+        EmailInfo info = createUniqueEmailInfo();
         info.setFromAddress("support@mycompany.com");
         info.setSendAsyncPriority("2");
         info.setSendEmailReliableAsync("false");
@@ -61,7 +61,7 @@ public class CoreEmailConfig {
     
     @Bean
     public EmailInfo blRegistrationEmailInfo() {
-        EmailInfo info = blEmailInfo();
+        EmailInfo info = createUniqueEmailInfo();
         info.setSubject("You have successfully registered!");
         info.setEmailTemplate("register-email");
         return info;
@@ -69,7 +69,7 @@ public class CoreEmailConfig {
     
     @Bean
     public EmailInfo blForgotPasswordEmailInfo() {
-        EmailInfo info = blEmailInfo();
+        EmailInfo info = createUniqueEmailInfo();
         info.setSubject("Reset password request");
         info.setEmailTemplate("resetPassword-email");
         return info;
@@ -77,7 +77,7 @@ public class CoreEmailConfig {
     
     @Bean
     public EmailInfo blOrderConfirmationEmailInfo() {
-        EmailInfo info = blEmailInfo();
+        EmailInfo info = createUniqueEmailInfo();
         info.setSubject("Your order with The Heat Clinic");
         info.setEmailTemplate("orderConfirmation-email");
         return info;
@@ -85,7 +85,7 @@ public class CoreEmailConfig {
     
     @Bean
     public EmailInfo blFulfillmentOrderTrackingEmailInfo() {
-        EmailInfo info = blEmailInfo();
+        EmailInfo info = createUniqueEmailInfo();
         info.setSubject("Your order with The Heat Clinic Has Shipped");
         info.setEmailTemplate("fulfillmentOrderTracking-email");
         return info;
@@ -93,7 +93,7 @@ public class CoreEmailConfig {
     
     @Bean
     public EmailInfo blReturnAuthorizationEmailInfo() {
-        EmailInfo info = blEmailInfo();
+        EmailInfo info = createUniqueEmailInfo();
         info.setSubject("Your return with The Heat Clinic");
         info.setEmailTemplate("returnAuthorization-email");
         return info;
@@ -101,9 +101,18 @@ public class CoreEmailConfig {
     
     @Bean
     public EmailInfo blReturnConfirmationEmailInfo() {
-        EmailInfo info = blEmailInfo();
+        EmailInfo info = createUniqueEmailInfo();
         info.setSubject("Your return with The Heat Clinic");
         info.setEmailTemplate("returnConfirmation-email");
         return info;
     }
+
+    protected EmailInfo createUniqueEmailInfo() {
+        EmailInfo info = new EmailInfo();
+        info.setFromAddress(propertiesService.resolveSystemProperty("smtp.fromAddress"));  
+        info.setSendAsyncPriority("2");
+        info.setSendEmailReliableAsync("false");
+        return info;
+    }
+
 }

--- a/core/src/main/java/com/community/core/config/CoreEmailConfig.java
+++ b/core/src/main/java/com/community/core/config/CoreEmailConfig.java
@@ -23,15 +23,16 @@ public class CoreEmailConfig {
      *   Port: 30000
      */
 //    @Bean
-//    public MailSender blMailSender() {
+//    public JavaMailSender blMailSender() {
 //        JavaMailSenderImpl sender = new JavaMailSenderImpl();
 //        sender.setHost("localhost");
-//        sender.setPort("30000");
+//        sender.setPort(30000);
 //        sender.setProtocol("smtp");
 //        Properties javaMailProps = new Properties();
-//        javaMailProps.setProperty("mail.smtp.starttls.enable", true);
-//        javaMailProps.setProperty("mail.smtp.timeout", 25000);
+//        javaMailProps.setProperty("mail.smtp.starttls.enable", ""+true);
+//        javaMailProps.setProperty("mail.smtp.timeout", "25000");
 //        sender.setJavaMailProperties(javaMailProps);
+//        return sender;
 //    }
     
     /**


### PR DESCRIPTION
This fixes the following defect:
All app-generated emails (forgot password, etc...) use the "returnConfirmation-email" template instead of their respective templates. So customers get a "return confirmation" email whether they create an account, reset password, etc....

Root cause: Each EmailInfo bean is initialized with the blEmailInfo() method which has the @Bean annotation, therefore these beans are all referenncing the same EmailInfo instance. During IOC initialization, they therefore all write information to the the same EmailInfo instance. The EmailInfo class contains the template information which gets overwritten during each of the bean initialization and end up containing the template for the last initialized bean "blReturnConfirmationEmailInfo".

Fix:
Move EmailInfo instance creation to a separate method that is not @Bean annotated and have each bean initialization method call it. This way a unique instance of EmailInfo is returned containing template information that is not overwritten.

Tested: yes.