### PR TITLE
Added Google Closure Compiler dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,5 +42,9 @@
             <groupId>org.broadleafcommerce</groupId>
             <artifactId>broadleaf-paypal</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.javascript</groupId>
+            <artifactId>closure-compiler</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <broadleaf-paypal.version>2.7.1-GA</broadleaf-paypal.version>
-
+        <google-closure-compiler.version>v20180204</google-closure-compiler.version>
+        
         <debug.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${debug.port}</debug.args>
         <boot.jvm.memory>-Xmx1536M</boot.jvm.memory>
         <boot.jvm.args>${boot.jvm.memory} ${debug.args}</boot.jvm.args>
@@ -93,6 +94,12 @@
                 <groupId>org.broadleafcommerce</groupId>
                 <artifactId>broadleaf-paypal</artifactId>
                 <version>${broadleaf-paypal.version}</version>
+            </dependency>
+            
+            <dependency>
+                <groupId>com.google.javascript</groupId>
+                <artifactId>closure-compiler</artifactId>
+                <version>${google-closure-compiler.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This dependency was added so that it will be used for JS minification instead of YUICompressor

BroadleafCommerce/QA#3232

depends on BroadleafCommerce/BroadleafCommerce#1827