### PR TITLE
Upgrade to Solr 7 and remove usage of solr.index.use.sku

### DIFF
--- a/core/src/main/java/com/community/core/config/ApplicationSolrConfiguration.java
+++ b/core/src/main/java/com/community/core/config/ApplicationSolrConfiguration.java
@@ -28,17 +28,17 @@ public class ApplicationSolrConfiguration {
 
     @Bean
     public SolrClient primaryCatalogSolrClient() {
-        return new HttpSolrClient(primaryCatalogSolrUrl);
+        return new HttpSolrClient.Builder(primaryCatalogSolrUrl).build();
     }
     
     @Bean
     public SolrClient reindexCatalogSolrClient() {
-        return new HttpSolrClient(reindexCatalogSolrUrl);
+        return new HttpSolrClient.Builder(reindexCatalogSolrUrl).build();
     }
     
     @Bean
     public SolrClient adminCatalogSolrClient() {
-        return new HttpSolrClient(adminCatalogSolrUrl);
+        return new HttpSolrClient.Builder(adminCatalogSolrUrl).build();
     }
 
     @Bean

--- a/site/src/main/java/com/community/controller/cart/CartController.java
+++ b/site/src/main/java/com/community/controller/cart/CartController.java
@@ -29,7 +29,6 @@ import org.broadleafcommerce.core.order.service.exception.UpdateCartException;
 import org.broadleafcommerce.core.pricing.service.exception.PricingException;
 import org.broadleafcommerce.core.web.controller.cart.BroadleafCartController;
 import org.broadleafcommerce.core.web.order.CartState;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -50,9 +49,6 @@ import javax.servlet.http.HttpServletResponse;
 @RequestMapping("/cart")
 public class CartController extends BroadleafCartController {
     
-    @Value("${solr.index.use.sku}")
-    protected boolean useSku;
-
     @Override
     @RequestMapping("")
     public String cart(HttpServletRequest request, HttpServletResponse response, Model model) throws PricingException {

--- a/site/src/main/resources/webTemplates/account/partials/wishlistItemsRow.html
+++ b/site/src/main/resources/webTemplates/account/partials/wishlistItemsRow.html
@@ -23,13 +23,7 @@
             <!-- Product Name -->
             <div class="col-lg-7">
                 <div class="cart-product-name text-uppercase">
-                    <a th:unless="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}" th:href="@{*{product.url}}" th:utext="*{name}"></a>
-                    <a th:if="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')} and *{sku.urlKey}" th:href="@{*{product.url} + *{sku.urlKey}}" th:inline="text">
-                        [[*{sku.name}]] <span th:each="optionValue : *{sku.productOptionValues}" th:utext="${optionValue.attributeValue}"></span>
-                    </a>
-                    <a th:if="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')} and !*{sku.urlKey}" th:href="@{*{product.url}}" th:inline="text">
-                        [[*{sku.name}]] <span th:each="optionValue : *{sku.productOptionValues}" th:utext="${optionValue.attributeValue}"></span>
-                    </a>
+                    <a th:href="@{*{product.url}}" th:utext="*{name}"></a>
                 </div>
             </div>
 

--- a/site/src/main/resources/webTemplates/cart/partials/cartProductRow.html
+++ b/site/src/main/resources/webTemplates/cart/partials/cartProductRow.html
@@ -24,13 +24,7 @@
             <div class="col-sm-7">
                 <div class="cart-product-name text-uppercase">
                     <th:block th:if="${item instanceof T(org.broadleafcommerce.core.order.domain.DiscreteOrderItem)}">
-                        <a th:unless="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}" th:href="@{*{product.url}}" th:utext="*{name}"></a>
-                        <a th:if="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')} and *{sku.urlKey}" th:href="@{*{product.url} + *{sku.urlKey}}" th:inline="text">
-                            [[*{sku.name}]] <span th:each="optionValue : *{sku.productOptionValues}" th:utext="${optionValue.attributeValue}"></span>
-                        </a>
-                        <a th:if="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')} and !*{sku.urlKey}" th:href="@{*{product.url}}" th:inline="text">
-                            [[*{sku.name}]] <span th:each="optionValue : *{sku.productOptionValues}" th:utext="${optionValue.attributeValue}"></span>
-                        </a>
+                        <a th:href="@{*{product.url}}" th:utext="*{name}"></a>
                     </th:block>
                     <th:block th:unless="${item instanceof T(org.broadleafcommerce.core.order.domain.DiscreteOrderItem)}">
                         <span th:utext="*{name}"></span>
@@ -104,13 +98,8 @@
                             </th:block>
 
                             <th:block th:if="${item instanceof T(org.broadleafcommerce.core.order.domain.DiscreteOrderItem)}">
-                                <a th:unless="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}"
-                                   class="btn btn-simple btn-bordered btn-xs remove-from-cart-action js-removeFromCart"
+                                <a class="btn btn-simple btn-bordered btn-xs remove-from-cart-action js-removeFromCart"
                                    th:href="@{/cart/remove(orderItemId=*{id}, productId=*{product.id})}"
-                                   th:utext="#{cart.remove}">Remove</a>
-                                <a th:if="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}"
-                                   class="btn btn-simple btn-bordered btn-xs remove-from-cart-action js-removeFromCart"
-                                   th:href="@{/cart/remove(orderItemId=*{id}, skuId=*{sku.id})}"
                                    th:utext="#{cart.remove}">Remove</a>
                             </th:block>
                             <th:block th:unless="${item instanceof T(org.broadleafcommerce.core.order.domain.DiscreteOrderItem)}">

--- a/site/src/main/resources/webTemplates/checkout/partials/miniCartItemList.html
+++ b/site/src/main/resources/webTemplates/checkout/partials/miniCartItemList.html
@@ -13,18 +13,7 @@
     <div class="mini-cart-item-info">
         <!-- Product Name -->
         <div class="mini-cart-item-name">
-            <th:block th:if="${item instanceof T(org.broadleafcommerce.core.order.domain.DiscreteOrderItem)}">
-                <span th:unless="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}" th:utext="*{name}"></span>
-                <span th:if="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')} and *{sku.urlKey}" th:inline="text">
-                        [[*{sku.name}]] <span th:each="optionValue : *{sku.productOptionValues}" th:utext="${optionValue.attributeValue}"></span>
-                    </span>
-                <span th:if="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')} and !*{sku.urlKey}" th:inline="text">
-                        [[*{sku.name}]] <span th:each="optionValue : *{sku.productOptionValues}" th:utext="${optionValue.attributeValue}"></span>
-                    </span>
-            </th:block>
-            <th:block th:unless="${item instanceof T(org.broadleafcommerce.core.order.domain.DiscreteOrderItem)}">
-                <span th:utext="*{name}"></span>
-            </th:block>
+            <span th:utext="*{name}"></span>
         </div>
 
         <blc:product_option_display orderItem="${item}">
@@ -48,8 +37,7 @@
                 </th:block>
 
                 <th:block th:if="${item instanceof T(org.broadleafcommerce.core.order.domain.DiscreteOrderItem)}">
-                    <a th:unless="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}" class="btn btn-simple btn-bordered btn-xs js-removeFromCart" th:href="@{/cart/remove(orderItemId=*{id}, productId=*{product.id})}">Remove</a>
-                    <a th:if="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}" class="btn btn-simple btn-bordered btn-xs js-removeFromCart" th:href="@{/cart/remove(orderItemId=*{id}, skuId=*{sku.id})}">Remove</a>
+                    <a class="btn btn-simple btn-bordered btn-xs js-removeFromCart" th:href="@{/cart/remove(orderItemId=*{id}, productId=*{product.id})}">Remove</a>
                 </th:block>
                 <th:block th:unless="${item instanceof T(org.broadleafcommerce.core.order.domain.DiscreteOrderItem)}">
                     <a class="btn btn-simple btn-xs js-removeFromCart" th:href="@{/cart/remove(orderItemId=*{id})}">Remove</a>

--- a/site/src/main/resources/webTemplates/checkout/partials/orderSummary.html
+++ b/site/src/main/resources/webTemplates/checkout/partials/orderSummary.html
@@ -28,13 +28,7 @@
                     <img th:if="*{#lists.isEmpty(sku.productOptionValues) and sku.skuMedia['primary'] != null}" th:src="@{*{sku.skuMedia['primary']?.url} + '?thumbnail'}" width="60" th:alt="*{sku.name}" />
                 </td>
                 <td align="left">
-                    <a th:unless="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')}" th:href="@{*{product.url}}" th:utext="*{product.name}"></a>
-                    <a th:if="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')} and *{sku.urlKey}" th:href="@{*{product.url} + *{sku.urlKey}}" th:inline="text">
-                       [[*{sku.name}]] <span th:each="optionValue : *{sku.productOptionValues}" th:utext="${optionValue.attributeValue}"></span>
-                    </a>
-                    <a th:if="${@blSystemPropertiesService.resolveBooleanSystemProperty('solr.index.use.sku')} and !*{sku.urlKey}" th:href="@{*{product.url}}" th:inline="text">
-                       [[*{sku.name}]] <span th:each="optionValue : *{sku.productOptionValues}" th:utext="${optionValue.attributeValue}"></span>
-                    </a>
+                    <a th:href="@{*{product.url}}" th:utext="*{product.name}"></a>
                     <br/>
                     <div th:replace="checkout/partials/orderItemConfigureMessaging"></div>
                     <blc:product_option_display orderItem="${item}" >


### PR DESCRIPTION
### Things that changed
- Removed all usage of solr.index.use.sku
- Updated the creation of HttpSolrClient to use the builder object provided
    - Previously you could instantiate the HttpSolrClient simply using the constructor, however in Solr 7 this constructor was made protected so we now use the Builder object provided by HttpSolrClient

Related to BroadleafCommerce/BroadleafCommerce#1890