### PR TITLE
Changed Google Closure Compiler artifact to the unshaded version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>com.google.javascript</groupId>
-            <artifactId>closure-compiler</artifactId>
+            <artifactId>closure-compiler-unshaded</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <google-closure-compiler.version>v20180204</google-closure-compiler.version>
+        <google-closure-compiler.version>v20180506</google-closure-compiler.version>
         
         <debug.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=${debug.port}</debug.args>
         <boot.jvm.memory>-Xmx1536M</boot.jvm.memory>
@@ -91,7 +91,7 @@
 
             <dependency>
                 <groupId>com.google.javascript</groupId>
-                <artifactId>closure-compiler</artifactId>
+                <artifactId>closure-compiler-unshaded</artifactId>
                 <version>${google-closure-compiler.version}</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION
The normal Google Closure Compiler dependency shades its dependencies (they're packaged inside the jar) so that maven is unable to manage the transitive dependencies. Moving to the unshaded version allows us to manage the dependencies properly.

Related to BroadleafCommerce/BroadleafCommerce#1905