### PR TITLE
Fix Thymeleaf layout dialect warnings

### DIFF
--- a/site/src/main/resources/webTemplates/layout/checkoutPageLayout.html
+++ b/site/src/main/resources/webTemplates/layout/checkoutPageLayout.html
@@ -4,8 +4,8 @@
 <!--[if IE 8]>    <html class="no-js lt-ie9" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 
-<head layout:fragment="custom-head">
-    <title layout:title-pattern="$DECORATOR_TITLE - $CONTENT_TITLE">
+<head>
+    <title layout:title-pattern="$LAYOUT_TITLE - $CONTENT_TITLE">
         Broadleaf Commerce Demo Store - Heat Clinic
     </title>
     <th:block th:include="layout/partials/head" />

--- a/site/src/main/resources/webTemplates/layout/fullPageLayout.html
+++ b/site/src/main/resources/webTemplates/layout/fullPageLayout.html
@@ -8,8 +8,8 @@
 <!--[if gt IE 8]><!-->
 <html class="no-js" lang="en"> <!--<![endif]-->
 
-<head layout:fragment="custom-head">
-    <title layout:title-pattern="$DECORATOR_TITLE - $CONTENT_TITLE">
+<head>
+    <title layout:title-pattern="$LAYOUT_TITLE - $CONTENT_TITLE">
         Broadleaf Commerce Demo Store - Heat Clinic
     </title>
     <th:block th:include="layout/partials/head"/>


### PR DESCRIPTION
- Replaced $DECORATOR_TITLE with $LAYOUT_TITLE
- Removed unnecessary head attribute layout:fragment="custom-head" from layout templates