### PR TITLE
BroadleafCommerce/QA#3465 - Remove deprecated Thymeleaf tags - replaced layout:decorator for layout:decorate

### DIFF
--- a/site/src/main/resources/webTemplates/content/news.html
+++ b/site/src/main/resources/webTemplates/content/news.html
@@ -1,4 +1,4 @@
-<th:block layout:decorator="layout/fullPageLayout" layout:fragment="content">
+<th:block layout:decorate="layout/fullPageLayout" layout:fragment="content">
     <head>
         <title th:text="${BLC_PAGE.description}"></title>
     </head>

--- a/site/src/main/resources/webTemplates/utility/error.html
+++ b/site/src/main/resources/webTemplates/utility/error.html
@@ -1,4 +1,4 @@
-<th:block layout:decorator="layout/fullPageLayout">
+<th:block layout:decorate="layout/fullPageLayout">
     <div layout:fragment="content">
         <div th:class="default_error_message">
             <h2>


### PR DESCRIPTION
ref QA issue [#3465](https://github.com/BroadleafCommerce/QA/issues/3465)