### PR TITLE
Remove internal SessionFixationProtectionFilter

### DIFF
--- a/core/src/main/resources/runtime-properties/common-shared.properties
+++ b/core/src/main/resources/runtime-properties/common-shared.properties
@@ -168,6 +168,9 @@ exception.handler.enabled=true
 # in favor of allowing our Thymeleaf view resolvers to handle errors.
 server.error.whitelabel.enabled=false
 
+# Turn off the legacy SessionFixationProtectionFilter
+filter.sessionFixationProtection.legacy.enabled=false
+
 # ##################################### #
 # PayPal Configuration                  #
 # ##################################### #

--- a/site/src/main/java/com/community/configuration/SiteSecurityConfig.java
+++ b/site/src/main/java/com/community/configuration/SiteSecurityConfig.java
@@ -23,7 +23,6 @@ import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.session.SessionManagementFilter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -84,9 +83,6 @@ public class SiteSecurityConfig extends WebSecurityConfigurerAdapter {
     @Resource(name="blCsrfFilter")
     protected Filter securityFilter;
 
-    @Resource(name="blSessionFixationProtectionFilter")
-    protected Filter sessionFixationProtectionFilter;
-
     @Resource(name="blUserDetailsService")
     protected UserDetailsService userDetailsService;
 
@@ -146,8 +142,7 @@ public class SiteSecurityConfig extends WebSecurityConfigurerAdapter {
                 .deleteCookies("ActiveID")
                 .logoutUrl("/logout")
                 .and()
-            .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(sessionFixationProtectionFilter, SessionManagementFilter.class);
+            .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class);
     }
 
     /**

--- a/site/src/main/java/com/community/configuration/SiteSecurityConfig.java
+++ b/site/src/main/java/com/community/configuration/SiteSecurityConfig.java
@@ -23,8 +23,6 @@ import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
-import org.springframework.security.web.authentication.session.SessionFixationProtectionStrategy;
 import org.springframework.security.web.session.SessionManagementFilter;
 
 import java.util.ArrayList;
@@ -124,9 +122,8 @@ public class SiteSecurityConfig extends WebSecurityConfigurerAdapter {
             .csrf().disable()
             .headers().frameOptions().disable().and()
             .sessionManagement()
-                .sessionAuthenticationStrategy(sessionAuthenticationStrategy())
                 .sessionFixation()
-                .none()
+                .migrateSession()
                 .enableSessionUrlRewriting(false)
                 .and()
             .formLogin()
@@ -168,10 +165,5 @@ public class SiteSecurityConfig extends WebSecurityConfigurerAdapter {
         return registrationBean;
     }
 
-
-    @Bean
-    public SessionAuthenticationStrategy sessionAuthenticationStrategy() {
-        return new SessionFixationProtectionStrategy();
-    }
 
 }

--- a/site/src/main/java/com/community/configuration/SiteSecurityConfig.java
+++ b/site/src/main/java/com/community/configuration/SiteSecurityConfig.java
@@ -3,7 +3,7 @@ package com.community.configuration;
 import org.broadleafcommerce.common.security.BroadleafAuthenticationFailureHandler;
 import org.broadleafcommerce.common.security.handler.SecurityFilter;
 import org.broadleafcommerce.core.web.order.security.BroadleafAuthenticationSuccessHandler;
-import org.broadleafcommerce.profile.web.site.security.LogUnsecuredSecureRequestFilter;
+import org.broadleafcommerce.profile.web.site.security.SessionFixationProtectionFilter;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -24,8 +24,6 @@ import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
-import org.springframework.security.web.authentication.session.SessionFixationProtectionStrategy;
 import org.springframework.security.web.session.SessionManagementFilter;
 
 import java.util.ArrayList;
@@ -87,8 +85,8 @@ public class SiteSecurityConfig extends WebSecurityConfigurerAdapter {
     @Resource(name="blCsrfFilter")
     protected Filter securityFilter;
 
-    @Resource(name="blLogUnsecuredSecureRequestFilter")
-    protected Filter logUnsecuredSecureRequestFilter;
+    @Resource(name="blSessionFixationProtectionFilter")
+    protected Filter sessionFixationProtectionFilter;
 
     @Resource(name="blUserDetailsService")
     protected UserDetailsService userDetailsService;
@@ -125,7 +123,6 @@ public class SiteSecurityConfig extends WebSecurityConfigurerAdapter {
             .csrf().disable()
             .headers().frameOptions().disable().and()
             .sessionManagement()
-                .sessionAuthenticationStrategy(sessionAuthenticationStrategy())
                 .sessionFixation()
                 .none()
                 .enableSessionUrlRewriting(false)
@@ -151,7 +148,7 @@ public class SiteSecurityConfig extends WebSecurityConfigurerAdapter {
                 .logoutUrl("/logout")
                 .and()
             .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(logUnsecuredSecureRequestFilter, SessionManagementFilter.class);
+            .addFilterBefore(sessionFixationProtectionFilter, SessionManagementFilter.class);
     }
 
     /**
@@ -177,14 +174,10 @@ public class SiteSecurityConfig extends WebSecurityConfigurerAdapter {
      * @return the registration bean that designates the filter as being disabled in the main flow
      */
     @Bean
-    public FilterRegistrationBean blSessionFixationProtectionFilterFilterRegistrationBean(@Qualifier("blLogUnsecuredSecureRequestFilter") LogUnsecuredSecureRequestFilter filter) {
+    public FilterRegistrationBean blSessionFixationProtectionFilterFilterRegistrationBean(@Qualifier("blSessionFixationProtectionFilter") SessionFixationProtectionFilter filter) {
         FilterRegistrationBean registrationBean = new FilterRegistrationBean(filter);
         registrationBean.setEnabled(false);
         return registrationBean;
     }
 
-    @Bean
-    public SessionAuthenticationStrategy sessionAuthenticationStrategy() {
-        return new SessionFixationProtectionStrategy();
-    }
 }

--- a/site/src/main/java/com/community/configuration/SiteSecurityConfig.java
+++ b/site/src/main/java/com/community/configuration/SiteSecurityConfig.java
@@ -3,7 +3,6 @@ package com.community.configuration;
 import org.broadleafcommerce.common.security.BroadleafAuthenticationFailureHandler;
 import org.broadleafcommerce.common.security.handler.SecurityFilter;
 import org.broadleafcommerce.core.web.order.security.BroadleafAuthenticationSuccessHandler;
-import org.broadleafcommerce.profile.web.site.security.SessionFixationProtectionFilter;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -24,6 +23,8 @@ import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+import org.springframework.security.web.authentication.session.SessionFixationProtectionStrategy;
 import org.springframework.security.web.session.SessionManagementFilter;
 
 import java.util.ArrayList;
@@ -123,6 +124,7 @@ public class SiteSecurityConfig extends WebSecurityConfigurerAdapter {
             .csrf().disable()
             .headers().frameOptions().disable().and()
             .sessionManagement()
+                .sessionAuthenticationStrategy(sessionAuthenticationStrategy())
                 .sessionFixation()
                 .none()
                 .enableSessionUrlRewriting(false)
@@ -166,18 +168,10 @@ public class SiteSecurityConfig extends WebSecurityConfigurerAdapter {
         return registrationBean;
     }
 
-    /**
-     * Don't allow the auto registration of the filter for the main request flow. This filter should be limited
-     * to the spring security chain.
-     *
-     * @param filter the Filter instance to disable in the main flow
-     * @return the registration bean that designates the filter as being disabled in the main flow
-     */
+
     @Bean
-    public FilterRegistrationBean blSessionFixationProtectionFilterFilterRegistrationBean(@Qualifier("blSessionFixationProtectionFilter") SessionFixationProtectionFilter filter) {
-        FilterRegistrationBean registrationBean = new FilterRegistrationBean(filter);
-        registrationBean.setEnabled(false);
-        return registrationBean;
+    public SessionAuthenticationStrategy sessionAuthenticationStrategy() {
+        return new SessionFixationProtectionStrategy();
     }
 
 }


### PR DESCRIPTION
**A Brief Overview**
1. Remove `SessionFixationProtectionFilter` from broadleaf-profile
2. Add a new filter for checking if requests are insecure
    - This should also have an environment property that makes it NO-OP
3. Replace, in the DemoSite and ReferenceSite configuration, `SessionFixationProtectionFilter` with the new logging filter


**Link to QA issue**
BroadleafCommerce/QA#4078
