### PR TITLE
Turn off caching for API and Site in development

### DIFF
--- a/admin/src/main/resources/bl-override-ehcache-admin.xml
+++ b/admin/src/main/resources/bl-override-ehcache-admin.xml
@@ -18,126 +18,7 @@
 
     <persistence directory="${java.io.tmpdir}/cache/admin"/>
 
-<!--     <defaultCache
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="blStandardElements"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3">
-        <cacheEventListenerFactory class="org.broadleafcommerce.common.cache.engine.HydratedCacheEventListenerFactory"/>
-    </cache>
-
-    <cache
-        name="blProducts"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3">
-        <cacheEventListenerFactory class="org.broadleafcommerce.common.cache.engine.HydratedCacheEventListenerFactory"/>
-    </cache>
-
-    <cache
-        name="blCategories"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3">
-        <cacheEventListenerFactory class="org.broadleafcommerce.common.cache.engine.HydratedCacheEventListenerFactory"/>
-    </cache>
-
-    <cache
-        name="blOffers"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3">
-        <cacheEventListenerFactory class="org.broadleafcommerce.common.cache.engine.HydratedCacheEventListenerFactory"/>
-    </cache>
-
-    <cache
-        name="blInventoryElements"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="org.hibernate.cache.internal.StandardQueryCache"
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="false"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="query.Catalog"
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="false"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="query.Offer"
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="false"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="blOrderElements"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-     <cache
-        name="blCustomerElements"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-     <cache
-        name="generatedResourceCache"
-        maxElementsInMemory="100"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-     <cache
-        name="blCMSElements"
-        maxElementsInMemory="10000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="blTranslationElements"
-        maxElementsInMemory="10000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="blConfigurationModuleElements"
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-     This is required by Hibernate to ensure that query caches return
-          corrrect results. It must contain at least as many entries as there are
-          DB tables.
-     <cache name="org.hibernate.cache.UpdateTimestampsCache"
-        maxElementsInMemory="5000"
-        eternal="true"
-        overflowToDisk="true"/> -->
-    <cache alias="blProducts">
+<!--     <cache alias="blProducts">
         <expiry>
             <ttl unit="seconds">3</ttl>
         </expiry>
@@ -230,5 +111,5 @@
             <ttl unit="seconds">3</ttl>
         </expiry>
         <heap unit="entries">5000</heap>
-    </cache>
+    </cache> -->
 </config>

--- a/admin/src/main/resources/runtime-properties/default.properties
+++ b/admin/src/main/resources/runtime-properties/default.properties
@@ -16,3 +16,5 @@ server.port=8444
 server.ssl.key-store = classpath:blc-example.keystore
 server.ssl.key-store-password = broadleaf
 server.ssl.key-password = broadleaf
+
+jcache.disable.cache=false

--- a/core/src/main/resources/runtime-properties/default-shared.properties
+++ b/core/src/main/resources/runtime-properties/default-shared.properties
@@ -77,3 +77,5 @@ site.baseurl=http://localhost:8080
 admin.baseurl=http://localhost:8081/admin
 
 crossapp.requireSsl=false
+
+jcache.disable.cache=true

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.broadleafcommerce</groupId>
         <artifactId>broadleaf-boot-starter-parent</artifactId>
-        <version>6.1.2-GA</version>
+        <version>6.1.3-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/site/src/main/resources/bl-override-ehcache.xml
+++ b/site/src/main/resources/bl-override-ehcache.xml
@@ -1,127 +1,8 @@
 <config>
 
     <persistence directory="${java.io.tmpdir}/cache/site"/>
-    
-<!--     <defaultCache
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
 
-    <cache
-        name="blStandardElements"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3">
-        <cacheEventListenerFactory class="org.broadleafcommerce.common.cache.engine.HydratedCacheEventListenerFactory"/>
-    </cache>
-
-    <cache
-        name="blProducts"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3">
-        <cacheEventListenerFactory class="org.broadleafcommerce.common.cache.engine.HydratedCacheEventListenerFactory"/>
-    </cache>
-
-    <cache
-        name="blCategories"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3">
-        <cacheEventListenerFactory class="org.broadleafcommerce.common.cache.engine.HydratedCacheEventListenerFactory"/>
-    </cache>
-
-    <cache
-        name="blOffers"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3">
-        <cacheEventListenerFactory class="org.broadleafcommerce.common.cache.engine.HydratedCacheEventListenerFactory"/>
-    </cache>
-
-    <cache
-        name="blInventoryElements"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="org.hibernate.cache.internal.StandardQueryCache"
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="false"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="query.Catalog"
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="false"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="query.Offer"
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="false"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="blOrderElements"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-     <cache
-        name="blCustomerElements"
-        maxElementsInMemory="100000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-     <cache
-        name="generatedResourceCache"
-        maxElementsInMemory="100"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-     <cache
-        name="blCMSElements"
-        maxElementsInMemory="10000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-    <cache
-        name="blTranslationElements"
-        maxElementsInMemory="10000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="5"/>
-
-    <cache
-        name="blConfigurationModuleElements"
-        maxElementsInMemory="1000"
-        eternal="false"
-        overflowToDisk="true"
-        timeToLiveSeconds="3"/>
-
-      This is required by Hibernate to ensure that query caches return
-          corrrect results. It must contain at least as many entries as there are
-          DB tables. 
-     <cache name="org.hibernate.cache.UpdateTimestampsCache"
-        maxElementsInMemory="5000"
-        eternal="true"
-        overflowToDisk="true"/> -->
-    <cache alias="blProducts">
+<!--     <cache alias="blProducts">
         <expiry>
             <ttl unit="seconds">3</ttl>
         </expiry>
@@ -214,5 +95,5 @@
             <ttl unit="seconds">3</ttl>
         </expiry>
         <heap unit="entries">5000</heap>
-    </cache>
+    </cache> -->
 </config>


### PR DESCRIPTION
Commented out the cache overrides since the defaults in Broadleaf are generally fine and additionally utilized the new jcache.disable.cache so that caching is disabled in development so that changes in the admin are immediately seen for api and site.

Depends on https://github.com/BroadleafCommerce/BroadleafCommerce/pull/2346
Goes with BroadleafCommerce/QA#4079