### PR TITLE
Remove blc:googleExpreiments from refernce

### DIFF
--- a/site/src/main/resources/webTemplates/layout/partials/head.html
+++ b/site/src/main/resources/webTemplates/layout/partials/head.html
@@ -61,7 +61,6 @@
 <script src="../../js/libs/modernizr-2.5.3.min.js" th:src="@{/js/libs/modernizr-2.5.3.min.js}"></script>
 
 <script src="//www.google-analytics.com/cx/api.js"></script>
-<blc:googleExperiments execute="true" ></blc:googleExperiments>
 <th:block th:utext="${experimentInfo}"></th:block>
 
 <blc:google_universal_analytics ordernumber="${order?.orderNumber}" ></blc:google_universal_analytics>


### PR DESCRIPTION
**A Brief Overview**
Remove tab  blc:googleexperiments. It is meant to be used for google content tests, as it is not really used and it was discontinued by Google.

**Link to QA issue**
BroadleafCommerce/QA#4086
