### PR TITLE
Fixed the issue where clicking back button in Safari or Firefox resubmits orders

### DIFF
--- a/site/src/main/resources/js/checkoutEventHandlers.js
+++ b/site/src/main/resources/js/checkoutEventHandlers.js
@@ -327,5 +327,12 @@ $body.on('click', '.js-edit-address', function() {
 $(function() {
     Checkout.initialize();
 
+    // Reloads page instead of loading it from the bfcache in Firefox and Safari
+    $(window).on("pageshow", function(event) {
+        if (event.originalEvent.persisted) {
+            window.location.reload()
+        }
+    });
+
     $('.js-paymentMethodCreditCard').click();
 });


### PR DESCRIPTION
Fixes BroadleafCommerce/QA#4173