### PR TITLE
replace static invocation in template to "VariableExpression" to overcome thymeleaf security

### DIFF
--- a/site/src/main/resources/webTemplates/catalog/partials/productSortOptions.html
+++ b/site/src/main/resources/webTemplates/catalog/partials/productSortOptions.html
@@ -15,7 +15,7 @@
                 <b class="caret"></b>
             </a>
             <ul class="dropdown-menu"
-                th:with="urlBuilder=${T(org.springframework.web.servlet.support.ServletUriComponentsBuilder).fromCurrentRequest()}">
+                th:with="urlBuilder=${#httpServletRequest.uriBuilderFromCurrentRequest()}">
 
                 <li><a th:href="${urlBuilder.replaceQueryParam('sort').toUriString()}"
                        th:unless="${param.sort == null}"


### PR DESCRIPTION
- replace static invocation in template to "VariableExpression" to overcome thymeleaf security

Fixes: BroadleafCommerce/QA#5112